### PR TITLE
fix(tts): normalize ElevenLabs loudness to fix volume swings

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod afplay;
 pub mod file;
+pub mod normalize;
 pub mod wav_header;
 
 pub use file::AudioFileProvider;

--- a/src/audio/normalize.rs
+++ b/src/audio/normalize.rs
@@ -40,7 +40,7 @@ const TARGET_LRA: &str = "11";
 /// so we parse it through `de_finite_f64`, which both converts to `f64` and
 /// rejects non-finite values — ffmpeg emits `"inf"` for silent clips — rather
 /// than letting them flow verbatim into the second pass's filter string.
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct LoudnormStats {
     #[serde(deserialize_with = "de_finite_f64")]
     input_i: f64,
@@ -90,6 +90,8 @@ pub(crate) fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<V
 
     if let Err(e) = std::fs::File::create(&in_path).and_then(|mut f| f.write_all(audio_data)) {
         tracing::debug!("loudnorm: failed to write temp input: {}", e);
+        // create() may have left a partial file behind before write_all failed.
+        let _ = std::fs::remove_file(&in_path);
         return None;
     }
 
@@ -98,7 +100,7 @@ pub(crate) fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<V
             return None;
         }
         std::fs::read(&out_path)
-            .map_err(|e| tracing::debug!("loudnorm: failed to read normalized output: {}", e))
+            .inspect_err(|e| tracing::debug!("loudnorm: failed to read normalized output: {}", e))
             .ok()
     });
 

--- a/src/audio/normalize.rs
+++ b/src/audio/normalize.rs
@@ -14,7 +14,8 @@
 use std::io::{Read, Write};
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::sync::mpsc;
+use std::time::Duration;
 
 /// Monotonic per-call counter so concurrent calls — even within one process,
 /// where the PID is identical — never collide on temp-file names.
@@ -110,8 +111,18 @@ pub(crate) fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<V
 /// can't deadlock us), and wait up to [`FFMPEG_TIMEOUT`]. On overrun the child
 /// is killed. Returns the exit status and captured stderr, or `None` if ffmpeg
 /// couldn't be spawned or timed out.
+///
+/// stdin is nulled so ffmpeg can't probe and consume the parent's stdin — which,
+/// in a Claude Code hook, carries the event JSON. The reader thread signals
+/// through a channel when stderr hits EOF (i.e. ffmpeg has closed its handles
+/// and is exiting), letting us block on a timeout instead of busy-polling.
 fn run_ffmpeg(mut command: Command) -> Option<(ExitStatus, Vec<u8>)> {
-    let mut child = match command.stdout(Stdio::null()).stderr(Stdio::piped()).spawn() {
+    let mut child = match command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
         Ok(child) => child,
         Err(e) => {
             tracing::debug!(
@@ -123,38 +134,31 @@ fn run_ffmpeg(mut command: Command) -> Option<(ExitStatus, Vec<u8>)> {
     };
 
     let stderr_pipe = child.stderr.take();
+    let (done_tx, done_rx) = mpsc::channel();
     let reader = std::thread::spawn(move || {
         let mut buf = Vec::new();
         if let Some(mut pipe) = stderr_pipe {
             let _ = pipe.read_to_end(&mut buf);
         }
+        let _ = done_tx.send(());
         buf
     });
 
-    let start = Instant::now();
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {
-                if start.elapsed() >= FFMPEG_TIMEOUT {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    let _ = reader.join();
-                    tracing::debug!("loudnorm: ffmpeg timed out, skipping normalization");
-                    return None;
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-            Err(e) => {
-                let _ = reader.join();
-                tracing::debug!("loudnorm: error waiting on ffmpeg ({})", e);
-                return None;
-            }
+    match done_rx.recv_timeout(FFMPEG_TIMEOUT) {
+        Ok(()) => {
+            // stderr closed ⇒ ffmpeg is exiting, so wait() returns promptly.
+            let status = child.wait().ok()?;
+            let stderr = reader.join().unwrap_or_default();
+            Some((status, stderr))
         }
-    };
-
-    let stderr = reader.join().unwrap_or_default();
-    Some((status, stderr))
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            tracing::debug!("loudnorm: ffmpeg timed out, skipping normalization");
+            None
+        }
+    }
 }
 
 /// First pass: measure the clip's loudness. Returns parsed stats, or `None` if

--- a/src/audio/normalize.rs
+++ b/src/audio/normalize.rs
@@ -11,12 +11,18 @@
 // feeds those measurements back with `linear=true` so ffmpeg applies one fixed
 // gain — accurate and consistent from clip to clip.
 
-use std::io::Write;
+use std::io::{Read, Write};
+use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 /// Monotonic per-call counter so concurrent calls — even within one process,
 /// where the PID is identical — never collide on temp-file names.
 static CALL_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Wall-clock cap per ffmpeg pass. A stalled ffmpeg would otherwise block the
+/// calling thread forever (worst case for a notification tool), so we kill it.
+const FFMPEG_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// EBU R128 integrated loudness target (LUFS). -16 is a common target for
 /// speech played back on consumer devices.
@@ -68,7 +74,7 @@ where
 ///
 /// Returns `None` when ffmpeg is unavailable or any step fails, so the caller
 /// can fall back to playing the original audio unmodified.
-pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>> {
+pub(crate) fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>> {
     let dir = std::env::temp_dir();
     // Qualify temp names with PID + a per-call counter so concurrent calls
     // (across or within a process) never clobber each other's files. The input
@@ -86,23 +92,76 @@ pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>>
         return None;
     }
 
-    let result = (|| {
-        let stats = measure(&in_path)?;
-        apply(&in_path, &out_path, &stats)?;
+    let result = measure(&in_path).and_then(|stats| {
+        if !apply(&in_path, &out_path, &stats) {
+            return None;
+        }
         std::fs::read(&out_path)
             .map_err(|e| tracing::debug!("loudnorm: failed to read normalized output: {}", e))
             .ok()
-    })();
+    });
 
     let _ = std::fs::remove_file(&in_path);
     let _ = std::fs::remove_file(&out_path);
     result
 }
 
+/// Spawn an ffmpeg command, drain its stderr on a helper thread (so a full pipe
+/// can't deadlock us), and wait up to [`FFMPEG_TIMEOUT`]. On overrun the child
+/// is killed. Returns the exit status and captured stderr, or `None` if ffmpeg
+/// couldn't be spawned or timed out.
+fn run_ffmpeg(mut command: Command) -> Option<(ExitStatus, Vec<u8>)> {
+    let mut child = match command.stdout(Stdio::null()).stderr(Stdio::piped()).spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            tracing::debug!(
+                "loudnorm: ffmpeg unavailable ({}), skipping normalization",
+                e
+            );
+            return None;
+        }
+    };
+
+    let stderr_pipe = child.stderr.take();
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stderr_pipe {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() >= FFMPEG_TIMEOUT {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = reader.join();
+                    tracing::debug!("loudnorm: ffmpeg timed out, skipping normalization");
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                let _ = reader.join();
+                tracing::debug!("loudnorm: error waiting on ffmpeg ({})", e);
+                return None;
+            }
+        }
+    };
+
+    let stderr = reader.join().unwrap_or_default();
+    Some((status, stderr))
+}
+
 /// First pass: measure the clip's loudness. Returns parsed stats, or `None` if
 /// ffmpeg is missing, exits non-zero, or its JSON can't be parsed.
 fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
-    let output = std::process::Command::new("ffmpeg")
+    let mut command = Command::new("ffmpeg");
+    command
         .arg("-hide_banner")
         .arg("-nostats")
         .arg("-i")
@@ -114,28 +173,17 @@ fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
         ))
         .arg("-f")
         .arg("null")
-        .arg("-")
-        .stdout(std::process::Stdio::null())
-        .output();
+        .arg("-");
 
-    let output = match output {
-        Ok(o) if o.status.success() => o,
-        Ok(_) => {
-            tracing::debug!("loudnorm: measure pass exited non-zero, skipping normalization");
-            return None;
-        }
-        Err(e) => {
-            tracing::debug!(
-                "loudnorm: ffmpeg unavailable ({}), skipping normalization",
-                e
-            );
-            return None;
-        }
-    };
+    let (status, stderr) = run_ffmpeg(command)?;
+    if !status.success() {
+        tracing::debug!("loudnorm: measure pass exited non-zero, skipping normalization");
+        return None;
+    }
 
     // loudnorm prints its JSON block to stderr; with -hide_banner -nostats it's
     // the only `{ ... }` there, so the last one is reliably the stats block.
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = String::from_utf8_lossy(&stderr);
     let json = stderr.rfind('{').and_then(|start| {
         stderr[start..]
             .rfind('}')
@@ -152,13 +200,10 @@ fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
 }
 
 /// Second pass: apply a single fixed gain (`linear=true`) using the measured
-/// values, writing a normalized WAV to `out_path`.
-fn apply(
-    in_path: &std::path::Path,
-    out_path: &std::path::Path,
-    stats: &LoudnormStats,
-) -> Option<()> {
-    let output = std::process::Command::new("ffmpeg")
+/// values, writing a normalized WAV to `out_path`. Returns `true` on success.
+fn apply(in_path: &std::path::Path, out_path: &std::path::Path, stats: &LoudnormStats) -> bool {
+    let mut command = Command::new("ffmpeg");
+    command
         .arg("-hide_banner")
         .arg("-nostats")
         .arg("-y")
@@ -178,24 +223,19 @@ fn apply(
         ))
         .arg("-f")
         .arg("wav")
-        .arg(out_path)
-        .stdout(std::process::Stdio::null())
-        .output();
+        .arg(out_path);
 
-    match output {
-        Ok(o) if o.status.success() => Some(()),
-        Ok(o) => {
+    match run_ffmpeg(command) {
+        Some((status, _)) if status.success() => true,
+        Some((status, stderr)) => {
             tracing::debug!(
                 "loudnorm: apply pass failed ({}): {}",
-                o.status,
-                String::from_utf8_lossy(&o.stderr).trim()
+                status,
+                String::from_utf8_lossy(&stderr).trim()
             );
-            None
+            false
         }
-        Err(e) => {
-            tracing::debug!("loudnorm: apply pass could not run ({})", e);
-            None
-        }
+        None => false,
     }
 }
 
@@ -203,11 +243,54 @@ fn apply(
 mod tests {
     use super::*;
 
+    /// `true` if an `ffmpeg` binary is callable, so happy-path tests can skip
+    /// cleanly on machines (e.g. minimal CI) without it.
+    fn ffmpeg_available() -> bool {
+        Command::new("ffmpeg")
+            .arg("-version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
     #[test]
     fn test_returns_none_on_garbage_input() {
         // Non-decodable bytes: ffmpeg (if present) fails to measure, ffmpeg-absent
         // also yields None. Either way the caller must get None and fall back.
         let result = normalize_to_wav(&[0xDE, 0xAD, 0xBE, 0xEF], "sumvox_test_norm");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_normalizes_valid_audio() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not available; skipping happy-path normalization test");
+            return;
+        }
+
+        // 3 s of a 440 Hz sine at 24 kHz, mono, 16-bit. loudnorm's integrated
+        // gating needs roughly a 3 s window to report finite stats, so a shorter
+        // clip would gate to -inf and (correctly) be rejected. Exercises the full
+        // filter string, guarding against arg-order or stats-parsing regressions
+        // the failure-path test can't catch.
+        let sample_rate = 24_000u32;
+        let samples = (sample_rate as f32 * 3.0) as usize;
+        let mut pcm = Vec::with_capacity(samples * 2);
+        for i in 0..samples {
+            let t = i as f32 / sample_rate as f32;
+            let amplitude = (std::f32::consts::TAU * 440.0 * t).sin() * 0.5;
+            let sample = (amplitude * i16::MAX as f32) as i16;
+            pcm.extend_from_slice(&sample.to_le_bytes());
+        }
+        let wav = crate::audio::wav_header::create_wav_file(&pcm, sample_rate, 1, 16);
+
+        let result = normalize_to_wav(&wav, "sumvox_test_happy");
+        assert!(result.is_some(), "valid audio should normalize to Some");
+        assert!(
+            !result.unwrap().is_empty(),
+            "normalized WAV should be non-empty"
+        );
     }
 }

--- a/src/audio/normalize.rs
+++ b/src/audio/normalize.rs
@@ -23,13 +23,39 @@ const TARGET_TP: &str = "-1.5";
 const TARGET_LRA: &str = "11";
 
 /// Measurements emitted by `loudnorm`'s first pass (`print_format=json`).
+///
+/// ffmpeg encodes each value as a JSON *string* (e.g. `"input_i" : "-15.66"`),
+/// so we parse it through `de_finite_f64`, which both converts to `f64` and
+/// rejects non-finite values — ffmpeg emits `"inf"` for silent clips — rather
+/// than letting them flow verbatim into the second pass's filter string.
 #[derive(serde::Deserialize)]
 struct LoudnormStats {
-    input_i: String,
-    input_tp: String,
-    input_lra: String,
-    input_thresh: String,
-    target_offset: String,
+    #[serde(deserialize_with = "de_finite_f64")]
+    input_i: f64,
+    #[serde(deserialize_with = "de_finite_f64")]
+    input_tp: f64,
+    #[serde(deserialize_with = "de_finite_f64")]
+    input_lra: f64,
+    #[serde(deserialize_with = "de_finite_f64")]
+    input_thresh: f64,
+    #[serde(deserialize_with = "de_finite_f64")]
+    target_offset: f64,
+}
+
+/// Parse loudnorm's stringified number into a finite `f64`, rejecting `inf` /
+/// `nan` / non-numeric so a bad measurement becomes a clean `None` upstream.
+fn de_finite_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let s = String::deserialize(deserializer)?;
+    let v: f64 = s.parse().map_err(serde::de::Error::custom)?;
+    if v.is_finite() {
+        Ok(v)
+    } else {
+        Err(serde::de::Error::custom(format!("non-finite value: {}", s)))
+    }
 }
 
 /// Normalize the loudness of `audio_data` (any format ffmpeg can decode) and
@@ -39,8 +65,12 @@ struct LoudnormStats {
 /// can fall back to playing the original audio unmodified.
 pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>> {
     let dir = std::env::temp_dir();
-    let in_path = dir.join(format!("{}_norm_in", temp_prefix));
-    let out_path = dir.join(format!("{}_norm_out.wav", temp_prefix));
+    // Include the PID so concurrent TTS calls don't clobber each other's temp
+    // files. The input keeps an `.mp3` extension so ffmpeg's demuxer detection
+    // is unambiguous.
+    let pid = std::process::id();
+    let in_path = dir.join(format!("{}_norm_{}_in.mp3", temp_prefix, pid));
+    let out_path = dir.join(format!("{}_norm_{}_out.wav", temp_prefix, pid));
 
     if let Err(e) = std::fs::File::create(&in_path).and_then(|mut f| f.write_all(audio_data)) {
         tracing::debug!("loudnorm: failed to write temp input: {}", e);
@@ -50,7 +80,9 @@ pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>>
     let result = (|| {
         let stats = measure(&in_path)?;
         apply(&in_path, &out_path, &stats)?;
-        std::fs::read(&out_path).ok()
+        std::fs::read(&out_path)
+            .map_err(|e| tracing::debug!("loudnorm: failed to read normalized output: {}", e))
+            .ok()
     })();
 
     let _ = std::fs::remove_file(&in_path);
@@ -62,6 +94,8 @@ pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>>
 /// ffmpeg is missing, exits non-zero, or its JSON can't be parsed.
 fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
     let output = std::process::Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-nostats")
         .arg("-i")
         .arg(in_path)
         .arg("-af")
@@ -89,7 +123,8 @@ fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
         }
     };
 
-    // loudnorm prints its JSON block to stderr; it's the last `{ ... }` there.
+    // loudnorm prints its JSON block to stderr; with -hide_banner -nostats it's
+    // the only `{ ... }` there, so the last one is reliably the stats block.
     let stderr = String::from_utf8_lossy(&output.stderr);
     let json = stderr.rfind('{').and_then(|start| {
         stderr[start..]
@@ -113,13 +148,15 @@ fn apply(
     out_path: &std::path::Path,
     stats: &LoudnormStats,
 ) -> Option<()> {
-    let status = std::process::Command::new("ffmpeg")
+    let output = std::process::Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-nostats")
         .arg("-y")
         .arg("-i")
         .arg(in_path)
         .arg("-af")
         .arg(format!(
-            "loudnorm=I={}:TP={}:LRA={}:measured_I={}:measured_TP={}:measured_LRA={}:measured_thresh={}:offset={}:linear=true:print_format=summary",
+            "loudnorm=I={}:TP={}:LRA={}:measured_I={:.2}:measured_TP={:.2}:measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear=true:print_format=summary",
             TARGET_I,
             TARGET_TP,
             TARGET_LRA,
@@ -133,13 +170,21 @@ fn apply(
         .arg("wav")
         .arg(out_path)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
+        .stderr(std::process::Stdio::piped())
+        .output();
 
-    match status {
-        Ok(s) if s.success() => Some(()),
-        _ => {
-            tracing::debug!("loudnorm: apply pass failed, skipping normalization");
+    match output {
+        Ok(o) if o.status.success() => Some(()),
+        Ok(o) => {
+            tracing::debug!(
+                "loudnorm: apply pass failed ({}): {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!("loudnorm: apply pass could not run ({})", e);
             None
         }
     }

--- a/src/audio/normalize.rs
+++ b/src/audio/normalize.rs
@@ -1,0 +1,159 @@
+// Loudness normalization via ffmpeg's `loudnorm` filter.
+//
+// ElevenLabs output (especially the highly expressive `eleven_v3` model) is not
+// loudness-normalized, so notifications swing loud/soft between — and within —
+// generations. Running each clip through `loudnorm` evens it out to a fixed
+// integrated loudness target before playback.
+//
+// We use the two-pass (measure → apply) flow: a single-pass `loudnorm` runs in
+// a time-varying "dynamic" mode that misses the target by several LUFS and is
+// inconsistent across clips. The first pass measures the clip, the second pass
+// feeds those measurements back with `linear=true` so ffmpeg applies one fixed
+// gain — accurate and consistent from clip to clip.
+
+use std::io::Write;
+
+/// EBU R128 integrated loudness target (LUFS). -16 is a common target for
+/// speech played back on consumer devices.
+const TARGET_I: &str = "-16";
+/// Max true peak (dBTP), leaving headroom to avoid clipping.
+const TARGET_TP: &str = "-1.5";
+/// Loudness range. Lower values compress dynamic swings more aggressively,
+/// which is exactly the "loud/soft" problem we want to tame.
+const TARGET_LRA: &str = "11";
+
+/// Measurements emitted by `loudnorm`'s first pass (`print_format=json`).
+#[derive(serde::Deserialize)]
+struct LoudnormStats {
+    input_i: String,
+    input_tp: String,
+    input_lra: String,
+    input_thresh: String,
+    target_offset: String,
+}
+
+/// Normalize the loudness of `audio_data` (any format ffmpeg can decode) and
+/// return WAV bytes.
+///
+/// Returns `None` when ffmpeg is unavailable or any step fails, so the caller
+/// can fall back to playing the original audio unmodified.
+pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>> {
+    let dir = std::env::temp_dir();
+    let in_path = dir.join(format!("{}_norm_in", temp_prefix));
+    let out_path = dir.join(format!("{}_norm_out.wav", temp_prefix));
+
+    if let Err(e) = std::fs::File::create(&in_path).and_then(|mut f| f.write_all(audio_data)) {
+        tracing::debug!("loudnorm: failed to write temp input: {}", e);
+        return None;
+    }
+
+    let result = (|| {
+        let stats = measure(&in_path)?;
+        apply(&in_path, &out_path, &stats)?;
+        std::fs::read(&out_path).ok()
+    })();
+
+    let _ = std::fs::remove_file(&in_path);
+    let _ = std::fs::remove_file(&out_path);
+    result
+}
+
+/// First pass: measure the clip's loudness. Returns parsed stats, or `None` if
+/// ffmpeg is missing, exits non-zero, or its JSON can't be parsed.
+fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
+    let output = std::process::Command::new("ffmpeg")
+        .arg("-i")
+        .arg(in_path)
+        .arg("-af")
+        .arg(format!(
+            "loudnorm=I={}:TP={}:LRA={}:print_format=json",
+            TARGET_I, TARGET_TP, TARGET_LRA
+        ))
+        .arg("-f")
+        .arg("null")
+        .arg("-")
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        Ok(_) => {
+            tracing::debug!("loudnorm: measure pass exited non-zero, skipping normalization");
+            return None;
+        }
+        Err(e) => {
+            tracing::debug!(
+                "loudnorm: ffmpeg unavailable ({}), skipping normalization",
+                e
+            );
+            return None;
+        }
+    };
+
+    // loudnorm prints its JSON block to stderr; it's the last `{ ... }` there.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let json = stderr.rfind('{').and_then(|start| {
+        stderr[start..]
+            .rfind('}')
+            .map(|end| &stderr[start..start + end + 1])
+    })?;
+
+    match serde_json::from_str::<LoudnormStats>(json) {
+        Ok(stats) => Some(stats),
+        Err(e) => {
+            tracing::debug!("loudnorm: failed to parse measure JSON ({})", e);
+            None
+        }
+    }
+}
+
+/// Second pass: apply a single fixed gain (`linear=true`) using the measured
+/// values, writing a normalized WAV to `out_path`.
+fn apply(
+    in_path: &std::path::Path,
+    out_path: &std::path::Path,
+    stats: &LoudnormStats,
+) -> Option<()> {
+    let status = std::process::Command::new("ffmpeg")
+        .arg("-y")
+        .arg("-i")
+        .arg(in_path)
+        .arg("-af")
+        .arg(format!(
+            "loudnorm=I={}:TP={}:LRA={}:measured_I={}:measured_TP={}:measured_LRA={}:measured_thresh={}:offset={}:linear=true:print_format=summary",
+            TARGET_I,
+            TARGET_TP,
+            TARGET_LRA,
+            stats.input_i,
+            stats.input_tp,
+            stats.input_lra,
+            stats.input_thresh,
+            stats.target_offset,
+        ))
+        .arg("-f")
+        .arg("wav")
+        .arg(out_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    match status {
+        Ok(s) if s.success() => Some(()),
+        _ => {
+            tracing::debug!("loudnorm: apply pass failed, skipping normalization");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_returns_none_on_garbage_input() {
+        // Non-decodable bytes: ffmpeg (if present) fails to measure, ffmpeg-absent
+        // also yields None. Either way the caller must get None and fall back.
+        let result = normalize_to_wav(&[0xDE, 0xAD, 0xBE, 0xEF], "sumvox_test_norm");
+        assert!(result.is_none());
+    }
+}

--- a/src/audio/normalize.rs
+++ b/src/audio/normalize.rs
@@ -12,6 +12,11 @@
 // gain — accurate and consistent from clip to clip.
 
 use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic per-call counter so concurrent calls — even within one process,
+/// where the PID is identical — never collide on temp-file names.
+static CALL_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// EBU R128 integrated loudness target (LUFS). -16 is a common target for
 /// speech played back on consumer devices.
@@ -65,12 +70,16 @@ where
 /// can fall back to playing the original audio unmodified.
 pub fn normalize_to_wav(audio_data: &[u8], temp_prefix: &str) -> Option<Vec<u8>> {
     let dir = std::env::temp_dir();
-    // Include the PID so concurrent TTS calls don't clobber each other's temp
-    // files. The input keeps an `.mp3` extension so ffmpeg's demuxer detection
-    // is unambiguous.
-    let pid = std::process::id();
-    let in_path = dir.join(format!("{}_norm_{}_in.mp3", temp_prefix, pid));
-    let out_path = dir.join(format!("{}_norm_{}_out.wav", temp_prefix, pid));
+    // Qualify temp names with PID + a per-call counter so concurrent calls
+    // (across or within a process) never clobber each other's files. The input
+    // keeps an `.mp3` extension so ffmpeg's demuxer detection is unambiguous.
+    let id = format!(
+        "{}_{}",
+        std::process::id(),
+        CALL_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+    let in_path = dir.join(format!("{}_norm_{}_in.mp3", temp_prefix, id));
+    let out_path = dir.join(format!("{}_norm_{}_out.wav", temp_prefix, id));
 
     if let Err(e) = std::fs::File::create(&in_path).and_then(|mut f| f.write_all(audio_data)) {
         tracing::debug!("loudnorm: failed to write temp input: {}", e);
@@ -106,6 +115,7 @@ fn measure(in_path: &std::path::Path) -> Option<LoudnormStats> {
         .arg("-f")
         .arg("null")
         .arg("-")
+        .stdout(std::process::Stdio::null())
         .output();
 
     let output = match output {
@@ -170,7 +180,6 @@ fn apply(
         .arg("wav")
         .arg(out_path)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
         .output();
 
     match output {

--- a/src/tts/elevenlabs.rs
+++ b/src/tts/elevenlabs.rs
@@ -93,6 +93,11 @@ impl ElevenLabsProvider {
         if let Some(wav) =
             crate::audio::normalize::normalize_to_wav(audio_data, "sumvox_elevenlabs")
         {
+            tracing::debug!(
+                "Playing loudness-normalized ElevenLabs audio: {} bytes, volume: {}",
+                wav.len(),
+                self.volume
+            );
             return crate::audio::afplay::play_with_afplay(&wav, self.volume, "sumvox_elevenlabs");
         }
 

--- a/src/tts/elevenlabs.rs
+++ b/src/tts/elevenlabs.rs
@@ -87,8 +87,17 @@ impl ElevenLabsProvider {
     }
 
     fn play_mp3(&self, audio_data: &[u8]) -> Result<()> {
+        // ElevenLabs output isn't loudness-normalized, so volume swings between
+        // (and within) generations. Even it out before playback; fall back to
+        // the raw MP3 when ffmpeg isn't installed.
+        if let Some(wav) =
+            crate::audio::normalize::normalize_to_wav(audio_data, "sumvox_elevenlabs")
+        {
+            return crate::audio::afplay::play_with_afplay(&wav, self.volume, "sumvox_elevenlabs");
+        }
+
         tracing::debug!(
-            "Playing ElevenLabs audio: {} bytes, volume: {}",
+            "Playing ElevenLabs audio without normalization: {} bytes, volume: {}",
             audio_data.len(),
             self.volume
         );

--- a/src/tts/elevenlabs.rs
+++ b/src/tts/elevenlabs.rs
@@ -86,7 +86,7 @@ impl ElevenLabsProvider {
             .map_err(|e| VoiceError::Voice(format!("Failed to create HTTP client: {}", e)))
     }
 
-    fn play_mp3(&self, audio_data: &[u8]) -> Result<()> {
+    fn play_audio(&self, audio_data: &[u8]) -> Result<()> {
         // ElevenLabs output isn't loudness-normalized, so volume swings between
         // (and within) generations. Even it out before playback; fall back to
         // the raw MP3 when ffmpeg isn't installed.
@@ -213,7 +213,7 @@ impl TtsProvider for ElevenLabsProvider {
 
         tracing::debug!("Received {} bytes of MP3 audio data", audio_data.len());
 
-        self.play_mp3(&audio_data)?;
+        self.play_audio(&audio_data)?;
 
         tracing::debug!("Voice playback completed");
         Ok(true)


### PR DESCRIPTION
## 問題

使用 ElevenLabs（尤其 `eleven_v3`）時通知音量忽大忽小。實測 raw 輸出每段 integrated loudness 在 -14.4～-15.4 LUFS 間飄移——ElevenLabs 不對輸出做 loudness normalization，而 `afplay -v` 是固定倍率，只能等比放大縮小，無法拉平源頭響度差。

## 修正

每段音檔播放前過一道 **兩段式 ffmpeg loudnorm**：
1. 第一段量測（`print_format=json`），解析 `input_i/tp/lra/thresh` + `target_offset`
2. 第二段帶回 `measured_*` + `linear=true`，套單一固定增益，精準命中 -16 LUFS

兩段式是必要的：單次 loudnorm 跑的是時變 dynamic 模式，會偏離目標數個 LUFS、跨段仍不一致。ffmpeg 缺席或任一段失敗時，優雅退回播放原始 MP3。

## 驗證

量測四段不同生成的正規化輸出，integrated loudness 全部落在 -15.98～-16.01 LUFS（差距 < 0.03 dB）：

```
clip 1:  raw_I=-14.79  →  norm_I=-16.01
clip 2:  raw_I=-14.66  →  norm_I=-15.98
clip 3:  raw_I=-14.44  →  norm_I=-15.98
clip 4:  raw_I=-15.35  →  norm_I=-15.99
```

`cargo test` 25 passed、`cargo clippy` 無警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)