### PR TITLE
ci: add Claude automated PR code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,39 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this Rust pull request, focusing on:
+            - Correctness bugs and edge cases (error handling, fallback paths)
+            - Idiomatic Rust and clippy-level issues
+            - Security implications (no leaked secrets, safe subprocess usage)
+            - Performance considerations
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ sumvox say "Test" --tts macos --voice Daniel
 - `src/main.rs` - Entry point, hook orchestration
 - `src/config.rs` - Configuration loading/saving
 - `src/transcript.rs` - Claude Code transcript parsing
-- `src/llm/` - Multi-provider LLM support (Gemini, Anthropic, OpenAI, Ollama)
-- `src/tts/` - Text-to-Speech engines (Google TTS, macOS say)
+- `src/llm/` - Multi-provider LLM support (Gemini, Anthropic, OpenAI, xAI Grok, Ollama)
+- `src/tts/` - Text-to-Speech engines (macOS say, Google TTS, Google Cloud TTS, xAI TTS, ElevenLabs)
 - `src/provider_factory.rs` - Provider creation with fallback chain
 
 ### Configuration Format

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,7 +34,7 @@ Replace `${PROVIDER_API_KEY}` with your actual API key:
 ```yaml
 providers:
   - name: google
-    model: gemini-2.5-flash
+    model: gemini-3.1-flash-lite
     api_key: "your-actual-api-key-here"  # Get from https://ai.google.dev
 ```
 
@@ -71,7 +71,7 @@ Edit `~/.claude/settings.json`:
 llm:
   providers:
     - name: google
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
       api_key: ${GEMINI_API_KEY}
     - name: ollama
       model: llama3.2

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ SumVox transforms your AI coding sessions into voice notifications. It reads Cla
 
 - ⚡ **Blazing Fast**: 7ms startup time (Rust implementation)
 - 🧠 **Multi-Model LLM Support**:
-  - Google Gemini (recommended, tested and optimized)
-  - Anthropic Claude, OpenAI GPT, Ollama (code support, not fully tested)
+  - Google Gemini (recommended, optimized)
+  - Anthropic Claude, OpenAI GPT, xAI Grok, Ollama
 - 🔊 **Multi-TTS Engines**:
+  - ElevenLabs TTS (premium natural voices, voice tuning, **volume control supported**)
   - xAI TTS (natural speech, 5 voices, **volume control supported**)
   - Google TTS (Gemini-powered, high quality, **volume control supported**)
   - Google Cloud TTS (Standard/WaveNet/Chirp3-HD voices, **volume control supported**)
@@ -75,7 +76,7 @@ sumvox init
 ```
 
 This creates `~/.config/sumvox/config.yaml` with sensible defaults:
-- **LLM**: Google Gemini + Ollama (local fallback)
+- **LLM**: Google Gemini → Anthropic → OpenAI → Ollama (fallback chain, local last)
 - **TTS**: macOS say (system default voice)
 - **Language**: English (customize in config)
 
@@ -93,7 +94,7 @@ Replace `${PROVIDER_API_KEY}` with your actual API key. For example, to use Goog
 llm:
   providers:
     - name: google
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
       api_key: "your-actual-api-key-here"  # Get from https://ai.google.dev
 ```
 
@@ -152,8 +153,16 @@ version: "1.0.0"
 llm:
   providers:
     - name: google
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
       api_key: ${GEMINI_API_KEY}
+      timeout: 10
+    - name: anthropic
+      model: claude-haiku-4-5-20251001
+      api_key: ${ANTHROPIC_API_KEY}
+      timeout: 10
+    - name: openai
+      model: gpt-5-nano
+      api_key: ${OPENAI_API_KEY}
       timeout: 10
     - name: ollama
       model: llama3.2
@@ -161,6 +170,7 @@ llm:
   parameters:
     max_tokens: 10000
     temperature: 0.3
+    disable_thinking: false
 
 tts:
   providers:
@@ -230,6 +240,7 @@ hooks:
 - `google` = Use only Google TTS (Gemini)
 - `xai` = Use only xAI TTS
 - `cloud_tts` = Use only Google Cloud TTS
+- `elevenlabs` = Use only ElevenLabs TTS
 - `auto` = Try all TTS providers in order (recommended for summaries)
 
 ### Configuration Examples
@@ -256,7 +267,7 @@ tts:
 llm:
   providers:
     - name: google
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
       api_key: ${GEMINI_API_KEY}
     - name: ollama
       model: llama3.2
@@ -397,7 +408,7 @@ llm:
     - name: anthropic
       model: claude-haiku-4-5-20251001
     - name: google
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
     - name: ollama
       model: llama3.2
 
@@ -422,7 +433,7 @@ tts:
 llm:
   providers:
     - name: google      # Free tier: 15 requests/min
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
     - name: ollama      # Unlimited local fallback
 
 tts:
@@ -469,6 +480,7 @@ sumvox say "Hello world"
 sumvox say "Hello" --tts macos
 sumvox say "Hello" --tts google --voice Aoede
 sumvox say "Hello" --tts xai --voice rex
+sumvox say "Hello" --tts elevenlabs --voice 21m00Tcm4TlvDq8ikWAM
 
 # Adjust speech rate (macOS only, 90-300)
 sumvox say "Hello" --rate 250
@@ -518,19 +530,21 @@ RUST_LOG=trace sumvox
 
 #### LLM Providers
 
-| Provider | Model | API Key Required | Speed | Cost | Tested |
-|----------|-------|------------------|-------|------|--------|
-| **Google Gemini** | `gemini-2.5-flash` | ✅ | Fast | Low | ✅ |
-| **Anthropic** | `claude-haiku-4-5-20251001` | ✅ | Fast | Medium | ⚠️ |
-| **OpenAI** | `gpt-4o-mini` | ✅ | Medium | Medium | ⚠️ |
-| **Ollama** | `llama3.2` | ❌ | Slow | Free | ✅ |
+| Provider | Model | API Key Required | Speed | Cost |
+|----------|-------|------------------|-------|------|
+| **Google Gemini** | `gemini-3.1-flash-lite` | ✅ | Fast | Low |
+| **Anthropic** | `claude-haiku-4-5-20251001` | ✅ | Fast | Medium |
+| **OpenAI** | `gpt-5-nano` | ✅ | Medium | Medium |
+| **xAI Grok** | `grok-build-0.1` | ✅ | Fast | Low |
+| **Ollama** | `llama3.2` | ❌ | Slow | Free |
 
-✅ = Fully tested | ⚠️ = Code support only
+**xAI Grok** uses the OpenAI-compatible endpoint at `https://api.x.ai/v1`. Use `name: xai` (or `grok`) in the LLM providers list.
 
 **Get API Keys:**
 - Gemini: https://ai.google.dev
 - Anthropic: https://console.anthropic.com
 - OpenAI: https://platform.openai.com
+- xAI Grok: https://console.x.ai
 
 #### TTS Providers
 
@@ -538,6 +552,7 @@ RUST_LOG=trace sumvox
 |----------|--------|------------------|-------|---------|------|----------------|
 | **macOS say** | System voices | ❌ | Instant | Good | Free | ❌ Not supported |
 | **xAI TTS** | 5 voices | ✅ | Fast | Excellent | $4.20/1M chars | ✅ Supported (0-100) |
+| **ElevenLabs TTS** | Library + Voice Design | ✅ | Fast | Premium | $0.06-0.12/1K chars | ✅ Supported (0-100) |
 | **Google TTS** | 6+ voices | ✅ | Fast | Excellent | ~$0.016/1K chars | ✅ Supported (0-100) |
 | **Google Cloud TTS** | 100+ voices | ✅ (Service Account) | Fast | Professional | $4-16/1M chars | ✅ Supported (0-100) |
 
@@ -552,6 +567,13 @@ RUST_LOG=trace sumvox
 - `eve` (default), `ara`, `rex`, `sal`, `leo`
 - Automatic language detection or specify with `language_code`
 - Get API key: https://console.x.ai
+- ✅ **Volume control supported** - adjust playback volume (0-100)
+
+**ElevenLabs TTS Voices:**
+- Voice selected by **Voice ID** (default: `21m00Tcm4TlvDq8ikWAM`, Rachel); browse the [voice library](https://elevenlabs.io/app/voice-library)
+- Models: `eleven_flash_v2_5`, `eleven_turbo_v2_5` (~75ms, $0.06/1K chars), `eleven_multilingual_v2`, `eleven_multilingual_v3` (~300ms, $0.12/1K chars)
+- Voice tuning: `speed` (0.7-1.2), `stability` (0.0-1.0), `style` (0.0-1.0)
+- API key from config `api_key` or `ELEVENLABS_API_KEY` env: https://elevenlabs.io/app/settings/api-keys
 - ✅ **Volume control supported** - adjust playback volume (0-100)
 
 **Google TTS Voices (Gemini):**
@@ -586,8 +608,8 @@ summarization:
 hooks:
   claude_code:
     notification_filter: [...]  # Which notification types to speak
-    notification_tts_provider: "macos" | "google" | "xai" | "cloud_tts" | "auto"
-    stop_tts_provider: "macos" | "google" | "xai" | "cloud_tts" | "auto"
+    notification_tts_provider: "macos" | "google" | "xai" | "cloud_tts" | "elevenlabs" | "auto"
+    stop_tts_provider: "macos" | "google" | "xai" | "cloud_tts" | "elevenlabs" | "auto"
 ```
 
 ### Environment Variables
@@ -595,7 +617,8 @@ hooks:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `SUMVOX_DISABLE` | Temporarily disable SumVox (any value) | `SUMVOX_DISABLE=1 claude` |
-| `XAI_API_KEY` | xAI API key (alternative to config) | `export XAI_API_KEY=xai-...` |
+| `XAI_API_KEY` | xAI API key for Grok LLM and xAI TTS (alternative to config) | `export XAI_API_KEY=xai-...` |
+| `ELEVENLABS_API_KEY` | ElevenLabs TTS API key (alternative to config) | `export ELEVENLABS_API_KEY=...` |
 | `RUST_LOG` | Set log level for debugging | `RUST_LOG=debug sumvox say "test"` |
 
 #### Temporarily Disable SumVox

--- a/config/recommended.toml
+++ b/config/recommended.toml
@@ -22,7 +22,7 @@ disable_thinking = false  # Set true to reduce token usage
 # Google Gemini (Recommended: fast, cheap, reliable)
 [[llm.providers]]
 name = "google"
-model = "gemini-2.5-flash"
+model = "gemini-3.1-flash-lite"
 api_key = "${PROVIDER_API_KEY}"  # Get from: https://ai.google.dev
 # base_url = "https://generativelanguage.googleapis.com/v1beta"  # Optional: custom API endpoint
 timeout = 10  # seconds
@@ -44,12 +44,11 @@ api_key = "${PROVIDER_API_KEY}"  # Get from: https://platform.openai.com
 timeout = 10
 
 # xAI Grok (OpenAI-compatible API; very cheap)
-# Pricing (Jan 2026): grok-4-1-fast: $0.20/$0.50 per 1M tokens (input/output)
 # Get API key: https://console.x.ai
 # Uncomment to enable:
 # [[llm.providers]]
 # name = "xai"
-# model = "grok-4-1-fast-non-reasoning"  # or grok-4-1-fast-reasoning, grok-4.3
+# model = "grok-build-0.1"  # or grok-4-1-fast-non-reasoning, grok-4-1-fast-reasoning
 # api_key = "${XAI_API_KEY}"
 # # base_url = "https://api.x.ai/v1"  # default; override only for proxies
 # timeout = 10

--- a/config/recommended.yaml
+++ b/config/recommended.yaml
@@ -12,7 +12,7 @@ llm:
   providers:
     # Google Gemini (Recommended: fast, cheap, reliable)
     - name: google
-      model: gemini-2.5-flash
+      model: gemini-3.1-flash-lite
       api_key: ${PROVIDER_API_KEY}  # Get from: https://ai.google.dev
       # base_url: https://generativelanguage.googleapis.com/v1beta  # Optional: custom API endpoint
       timeout: 10  # seconds

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,7 @@ impl Default for LlmConfig {
             providers: vec![
                 LlmProviderConfig {
                     name: "google".to_string(),
-                    model: "gemini-2.5-flash".to_string(),
+                    model: "gemini-3.1-flash-lite".to_string(),
                     api_key: None,
                     base_url: None,
                     timeout: default_timeout(),

--- a/src/hooks/claude_code.rs
+++ b/src/hooks/claude_code.rs
@@ -12,7 +12,7 @@ use crate::llm::GenerationRequest;
 use crate::provider_factory::ProviderFactory;
 use crate::queue::{NotificationQueue, QueueLock};
 use crate::transcript::TranscriptReader;
-use crate::tts::{create_tts_by_name, create_tts_from_config, TtsEngine, TtsProvider};
+use crate::tts::{create_tts_from_config, resolve_tts_provider, TtsEngine, TtsProvider};
 
 /// Claude Code hook input structure
 #[derive(Debug, Deserialize)]
@@ -350,17 +350,43 @@ async fn generate_summary(
 
     // Try providers with fallback
     if llm_opts.provider.is_some() || llm_opts.model.is_some() {
-        // CLI specified - try only that provider
-        let provider_name = llm_opts.provider.as_deref().unwrap_or("google");
-        let model_name = llm_opts.model.as_deref().unwrap_or("gemini-2.5-flash");
+        // CLI specified at least one of provider/model - try only that provider.
+        // Defaults are resolved from config, never hardcoded:
+        //   provider -> first configured provider; model -> that provider's configured model.
+        let provider_name = match llm_opts
+            .provider
+            .as_deref()
+            .or_else(|| llm_config.providers.first().map(|p| p.name.as_str()))
+        {
+            Some(name) => name,
+            None => {
+                tracing::error!("No LLM provider specified and none configured");
+                return Ok(String::new());
+            }
+        };
         let timeout = Duration::from_secs(llm_opts.timeout);
 
-        // Find the matching provider config for per-provider override resolution
+        // Find the matching provider config for model + per-provider override resolution
         let matching_provider = config
             .llm
             .providers
             .iter()
             .find(|p| p.name.to_lowercase() == provider_name.to_lowercase());
+
+        let model_name = match llm_opts
+            .model
+            .as_deref()
+            .or_else(|| matching_provider.map(|p| p.model.as_str()))
+        {
+            Some(model) => model,
+            None => {
+                tracing::error!(
+                    "CLI provider '{}' not found in config and no --model provided",
+                    provider_name
+                );
+                return Ok(String::new());
+            }
+        };
 
         let api_key = matching_provider.and_then(|p| p.get_api_key());
 
@@ -476,148 +502,51 @@ async fn speak_text(config: &SumvoxConfig, tts_opts: &TtsOptions, text: &str) ->
             // Use config fallback chain
             create_tts_from_config(&config.tts.providers)?
         }
-        TtsEngine::MacOS => {
-            // Get macOS config for fallback values
-            let macos_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| p.name.to_lowercase() == "macos");
-
-            // Priority: CLI > Config > Default
-            let voice = tts_opts
-                .voice
-                .clone()
-                .or_else(|| macos_config.and_then(|p| p.voice.clone()));
-
-            let volume = tts_opts
-                .volume
-                .or_else(|| macos_config.and_then(|p| p.volume))
-                .unwrap_or(100);
-
-            create_tts_by_name("macos", None, voice, tts_opts.rate, volume, None)?
-        }
-        TtsEngine::Google => {
-            // Get Google config for fallback values
-            let google_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| p.name.to_lowercase() == "google");
-
-            // Get API key from config or env
-            let api_key = google_config.and_then(|p| p.get_api_key());
-
-            // Model is required for Google TTS
-            let model = google_config
-                .and_then(|p| p.model.clone())
-                .or_else(|| Some("gemini-2.5-flash-preview-tts".to_string()));
-
-            // Priority: CLI > Config > Default
-            let voice = tts_opts
-                .voice
-                .clone()
-                .or_else(|| google_config.and_then(|p| p.voice.clone()))
-                .unwrap_or_else(|| "Zephyr".to_string());
-
-            let volume = tts_opts
-                .volume
-                .or_else(|| google_config.and_then(|p| p.volume))
-                .unwrap_or(100);
-
-            create_tts_by_name("google", model, Some(voice), tts_opts.rate, volume, api_key)?
-        }
-        TtsEngine::CloudTts => {
-            let cloud_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| {
-                    matches!(
-                        p.name.to_lowercase().as_str(),
-                        "cloud_tts" | "gcp_tts" | "google_cloud"
-                    )
-                })
-                .ok_or_else(|| {
-                    crate::error::VoiceError::Config(
-                        "cloud_tts provider not found in config".into(),
-                    )
-                })?;
-
-            // Apply hook volume override
-            let mut cloud_config = cloud_config.clone();
-            if let Some(vol) = tts_opts.volume {
-                cloud_config.volume = Some(vol);
-            }
-
-            crate::tts::create_single_tts(&cloud_config)?
-        }
-        TtsEngine::AudioFile => {
-            let audio_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| {
-                    matches!(
-                        p.name.to_lowercase().as_str(),
-                        "audio_file" | "audio" | "file"
-                    )
-                })
-                .ok_or_else(|| {
-                    crate::error::VoiceError::Config(
-                        "audio_file provider not found in config".into(),
-                    )
-                })?;
-
-            // Apply hook volume override (priority: CLI > hook config > provider config)
-            let mut audio_config = audio_config.clone();
-            if let Some(vol) = tts_opts.volume {
-                audio_config.volume = Some(vol);
-            }
-
-            crate::tts::create_single_tts(&audio_config)?
-        }
-        TtsEngine::Xai => {
-            let xai_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| matches!(p.name.to_lowercase().as_str(), "xai" | "xai_tts" | "grok"))
-                .ok_or_else(|| {
-                    crate::error::VoiceError::Config("xai provider not found in config".into())
-                })?;
-
-            let mut xai_config = xai_config.clone();
-            if let Some(vol) = tts_opts.volume {
-                xai_config.volume = Some(vol);
-            }
-
-            crate::tts::create_single_tts(&xai_config)?
-        }
-        TtsEngine::ElevenLabs => {
-            let el_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| {
-                    matches!(
-                        p.name.to_lowercase().as_str(),
-                        "elevenlabs" | "eleven_labs" | "11labs"
-                    )
-                })
-                .ok_or_else(|| {
-                    crate::error::VoiceError::Config(
-                        "elevenlabs provider not found in config".into(),
-                    )
-                })?;
-
-            let mut el_config = el_config.clone();
-            if let Some(vol) = tts_opts.volume {
-                el_config.volume = Some(vol);
-            }
-
-            crate::tts::create_single_tts(&el_config)?
-        }
+        // An explicitly selected engine overrides which configured provider to use;
+        // all attributes come from that config entry, with only explicit CLI/hook
+        // voice/volume layered on top. Nothing is hardcoded.
+        TtsEngine::MacOS => resolve_tts_provider(
+            &config.tts.providers,
+            &["macos", "say"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::Google => resolve_tts_provider(
+            &config.tts.providers,
+            &["google", "google_tts", "gcloud", "gemini"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::CloudTts => resolve_tts_provider(
+            &config.tts.providers,
+            &["cloud_tts", "gcp_tts", "google_cloud"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::AudioFile => resolve_tts_provider(
+            &config.tts.providers,
+            &["audio_file", "audio", "file"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::Xai => resolve_tts_provider(
+            &config.tts.providers,
+            &["xai", "xai_tts", "grok"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::ElevenLabs => resolve_tts_provider(
+            &config.tts.providers,
+            &["elevenlabs", "eleven_labs", "11labs"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
     };
 
     if !provider.is_available() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,9 @@ use hooks::claude_code::{ClaudeCodeInput, LlmOptions, TtsOptions};
 use hooks::HookFormat;
 use llm::GenerationRequest;
 use provider_factory::ProviderFactory;
-use tts::{create_single_tts, create_tts_by_name, create_tts_from_config, TtsEngine, TtsProvider};
+use tts::{
+    create_single_tts, create_tts_from_config, resolve_tts_provider, TtsEngine, TtsProvider,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -331,17 +333,43 @@ async fn generate_summary(
 
     // Try providers with fallback
     if llm_opts.provider.is_some() || llm_opts.model.is_some() {
-        // CLI specified - try only that provider
-        let provider_name = llm_opts.provider.as_deref().unwrap_or("google");
-        let model_name = llm_opts.model.as_deref().unwrap_or("gemini-2.5-flash");
+        // CLI specified at least one of provider/model - try only that provider.
+        // Defaults are resolved from config, never hardcoded:
+        //   provider -> first configured provider; model -> that provider's configured model.
+        let provider_name = match llm_opts
+            .provider
+            .as_deref()
+            .or_else(|| llm_config.providers.first().map(|p| p.name.as_str()))
+        {
+            Some(name) => name,
+            None => {
+                tracing::error!("No LLM provider specified and none configured");
+                return Ok(String::new());
+            }
+        };
         let timeout = Duration::from_secs(llm_opts.timeout);
 
-        // Find the matching provider config for per-provider override resolution
+        // Find the matching provider config for model + per-provider override resolution
         let matching_provider = config
             .llm
             .providers
             .iter()
             .find(|p| p.name.to_lowercase() == provider_name.to_lowercase());
+
+        let model_name = match llm_opts
+            .model
+            .as_deref()
+            .or_else(|| matching_provider.map(|p| p.model.as_str()))
+        {
+            Some(model) => model,
+            None => {
+                tracing::error!(
+                    "CLI provider '{}' not found in config and no --model provided",
+                    provider_name
+                );
+                return Ok(String::new());
+            }
+        };
 
         let api_key = matching_provider.and_then(|p| p.get_api_key());
 
@@ -457,116 +485,51 @@ async fn speak_text(config: &SumvoxConfig, tts_opts: &TtsOptions, text: &str) ->
             // Use config fallback chain
             create_tts_from_config(&config.tts.providers)?
         }
-        TtsEngine::MacOS => {
-            // Get macOS config for fallback values
-            let macos_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| p.name.to_lowercase() == "macos");
-
-            // Priority: CLI > Config > Default
-            let voice = tts_opts
-                .voice
-                .clone()
-                .or_else(|| macos_config.and_then(|p| p.voice.clone()));
-
-            let volume = tts_opts
-                .volume
-                .or_else(|| macos_config.and_then(|p| p.volume))
-                .unwrap_or(100);
-
-            create_tts_by_name("macos", None, voice, tts_opts.rate, volume, None)?
-        }
-        TtsEngine::Google => {
-            // Get Google config for fallback values
-            let google_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| p.name.to_lowercase() == "google");
-
-            // Get API key from config or env
-            let api_key = google_config.and_then(|p| p.get_api_key());
-
-            // Model is required for Google TTS
-            let model = google_config
-                .and_then(|p| p.model.clone())
-                .or_else(|| Some("gemini-2.5-flash-preview-tts".to_string()));
-
-            // Priority: CLI > Config > Default
-            let voice = tts_opts
-                .voice
-                .clone()
-                .or_else(|| google_config.and_then(|p| p.voice.clone()))
-                .unwrap_or_else(|| "Zephyr".to_string());
-
-            let volume = tts_opts
-                .volume
-                .or_else(|| google_config.and_then(|p| p.volume))
-                .unwrap_or(100);
-
-            create_tts_by_name("google", model, Some(voice), tts_opts.rate, volume, api_key)?
-        }
-        TtsEngine::CloudTts => {
-            // Find cloud_tts config from config
-            let cloud_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| {
-                    matches!(
-                        p.name.to_lowercase().as_str(),
-                        "cloud_tts" | "gcp_tts" | "google_cloud"
-                    )
-                })
-                .ok_or_else(|| {
-                    VoiceError::Config("cloud_tts provider not found in config".into())
-                })?;
-            create_single_tts(cloud_config)?
-        }
-        TtsEngine::AudioFile => {
-            // Find audio_file config from config
-            let audio_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| {
-                    matches!(
-                        p.name.to_lowercase().as_str(),
-                        "audio_file" | "audio" | "file"
-                    )
-                })
-                .ok_or_else(|| {
-                    VoiceError::Config("audio_file provider not found in config".into())
-                })?;
-            create_single_tts(audio_config)?
-        }
-        TtsEngine::Xai => {
-            let xai_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| matches!(p.name.to_lowercase().as_str(), "xai" | "xai_tts" | "grok"))
-                .ok_or_else(|| VoiceError::Config("xai provider not found in config".into()))?;
-            create_single_tts(xai_config)?
-        }
-        TtsEngine::ElevenLabs => {
-            let el_config = config
-                .tts
-                .providers
-                .iter()
-                .find(|p| {
-                    matches!(
-                        p.name.to_lowercase().as_str(),
-                        "elevenlabs" | "eleven_labs" | "11labs"
-                    )
-                })
-                .ok_or_else(|| {
-                    VoiceError::Config("elevenlabs provider not found in config".into())
-                })?;
-            create_single_tts(el_config)?
-        }
+        // For an explicitly selected engine, `--tts X` overrides which configured
+        // provider to use; all attributes are sourced from that config entry, with
+        // only explicit CLI voice/volume layered on top. Nothing is hardcoded.
+        TtsEngine::MacOS => resolve_tts_provider(
+            &config.tts.providers,
+            &["macos", "say"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::Google => resolve_tts_provider(
+            &config.tts.providers,
+            &["google", "google_tts", "gcloud", "gemini"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::CloudTts => resolve_tts_provider(
+            &config.tts.providers,
+            &["cloud_tts", "gcp_tts", "google_cloud"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::AudioFile => resolve_tts_provider(
+            &config.tts.providers,
+            &["audio_file", "audio", "file"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::Xai => resolve_tts_provider(
+            &config.tts.providers,
+            &["xai", "xai_tts", "grok"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
+        TtsEngine::ElevenLabs => resolve_tts_provider(
+            &config.tts.providers,
+            &["elevenlabs", "eleven_labs", "11labs"],
+            tts_opts.voice.as_deref(),
+            tts_opts.rate,
+            tts_opts.volume,
+        )?,
     };
 
     if !provider.is_available() {

--- a/src/tts/cloud_tts.rs
+++ b/src/tts/cloud_tts.rs
@@ -59,26 +59,17 @@ struct TtsResponse {
 impl CloudTtsProvider {
     pub fn new(
         service_account_json: String,
-        voice: Option<String>,
+        voice: String,
         language_code: Option<String>,
         volume: u32,
     ) -> Self {
-        let lang_code = language_code.clone().unwrap_or_else(|| "en-US".to_string());
-
-        // Determine default voice based on language code
-        // Google Cloud TTS uses "cmn-TW" for Mandarin (Taiwan), not "zh-TW"
-        let default_voice = if lang_code.starts_with("cmn") || lang_code.starts_with("zh") {
-            format!("{}-Standard-A", lang_code)
-        } else {
-            "en-US-Standard-A".to_string()
-        };
-
-        let voice_name = voice.unwrap_or(default_voice);
+        // language_code is a neutral tuning value: unset = en-US.
+        let lang_code = language_code.unwrap_or_else(|| "en-US".to_string());
 
         Self {
             auth: CloudTtsAuth::new(service_account_json.clone()),
             service_account_json,
-            voice: voice_name,
+            voice,
             language_code: lang_code,
             volume,
         }
@@ -237,7 +228,7 @@ mod tests {
     fn create_test_provider() -> CloudTtsProvider {
         CloudTtsProvider::new(
             r#"{"client_email":"test@test.com","private_key":"key"}"#.to_string(),
-            None,
+            "en-US-Standard-A".to_string(),
             None,
             100,
         )
@@ -257,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_is_available_empty() {
-        let p = CloudTtsProvider::new(String::new(), None, None, 100);
+        let p = CloudTtsProvider::new(String::new(), "en-US-Standard-A".to_string(), None, 100);
         assert!(!p.is_available());
     }
 
@@ -275,15 +266,10 @@ mod tests {
     }
 
     #[test]
-    fn test_default_voice_zh() {
-        let p = CloudTtsProvider::new("sa".into(), None, Some("cmn-TW".into()), 100);
-        assert_eq!(p.voice, "cmn-TW-Standard-A");
-        assert_eq!(p.language_code, "cmn-TW");
-    }
-
-    #[test]
-    fn test_default_voice_en() {
-        let p = CloudTtsProvider::new("sa".into(), None, None, 100);
+    fn test_language_defaults_to_en_us_when_absent() {
+        // voice is required and used verbatim; language_code is a neutral tuning
+        // value, defaulting to en-US only when the config leaves it unset.
+        let p = CloudTtsProvider::new("sa".into(), "en-US-Standard-A".into(), None, 100);
         assert_eq!(p.voice, "en-US-Standard-A");
         assert_eq!(p.language_code, "en-US");
     }
@@ -292,7 +278,7 @@ mod tests {
     fn test_custom_voice() {
         let p = CloudTtsProvider::new(
             "sa".into(),
-            Some("zh-TW-Wavenet-B".into()),
+            "zh-TW-Wavenet-B".into(),
             Some("zh-TW".into()),
             100,
         );

--- a/src/tts/elevenlabs.rs
+++ b/src/tts/elevenlabs.rs
@@ -13,12 +13,6 @@ use crate::error::{Result, VoiceError};
 
 const ELEVENLABS_API_BASE: &str = "https://api.elevenlabs.io/v1/text-to-speech";
 
-/// Default voice ID — "Rachel" (one of ElevenLabs' stock voices)
-const DEFAULT_VOICE_ID: &str = "21m00Tcm4TlvDq8ikWAM";
-
-/// Default model — Flash v2.5: ~75ms latency, $0.06/1K chars
-const DEFAULT_MODEL_ID: &str = "eleven_flash_v2_5";
-
 /// Default output format — MP3 44.1kHz 128kbps (free tier)
 const DEFAULT_OUTPUT_FORMAT: &str = "mp3_44100_128";
 
@@ -65,8 +59,8 @@ struct VoiceSettings {
 impl ElevenLabsProvider {
     pub fn new(
         api_key: String,
-        voice_id: Option<String>,
-        model_id: Option<String>,
+        voice_id: String,
+        model_id: String,
         speed: Option<f32>,
         stability: Option<f32>,
         style: Option<f32>,
@@ -74,8 +68,8 @@ impl ElevenLabsProvider {
     ) -> Self {
         Self {
             api_key,
-            voice_id: voice_id.unwrap_or_else(|| DEFAULT_VOICE_ID.to_string()),
-            model_id: model_id.unwrap_or_else(|| DEFAULT_MODEL_ID.to_string()),
+            voice_id,
+            model_id,
             output_format: DEFAULT_OUTPUT_FORMAT.to_string(),
             speed: speed.map(|s| s.clamp(0.7, 1.2)),
             stability: stability.map(|s| s.clamp(0.0, 1.0)),
@@ -227,11 +221,18 @@ mod tests {
 
     #[test]
     fn test_provider_creation_defaults() {
-        let provider =
-            ElevenLabsProvider::new("test-key".to_string(), None, None, None, None, None, 100);
+        let provider = ElevenLabsProvider::new(
+            "test-key".to_string(),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
+            None,
+            None,
+            None,
+            100,
+        );
         assert_eq!(provider.name(), "elevenlabs");
-        assert_eq!(provider.voice_id, DEFAULT_VOICE_ID);
-        assert_eq!(provider.model_id, DEFAULT_MODEL_ID);
+        assert_eq!(provider.voice_id, "21m00Tcm4TlvDq8ikWAM");
+        assert_eq!(provider.model_id, "eleven_flash_v2_5");
         assert_eq!(provider.volume, 100);
         assert!(provider.is_available());
     }
@@ -240,8 +241,8 @@ mod tests {
     fn test_provider_custom_voice_and_model() {
         let provider = ElevenLabsProvider::new(
             "test-key".to_string(),
-            Some("JBFqnCBsd6RMkjVDRZzb".to_string()),
-            Some("eleven_multilingual_v2".to_string()),
+            "JBFqnCBsd6RMkjVDRZzb".to_string(),
+            "eleven_multilingual_v2".to_string(),
             Some(0.85),
             None,
             None,
@@ -255,23 +256,45 @@ mod tests {
 
     #[test]
     fn test_speed_clamped_to_valid_range() {
-        let too_slow =
-            ElevenLabsProvider::new("k".to_string(), None, None, Some(0.5), None, None, 100);
+        let too_slow = ElevenLabsProvider::new(
+            "k".to_string(),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
+            Some(0.5),
+            None,
+            None,
+            100,
+        );
         assert_eq!(too_slow.speed, Some(0.7));
-        let too_fast =
-            ElevenLabsProvider::new("k".to_string(), None, None, Some(2.0), None, None, 100);
+        let too_fast = ElevenLabsProvider::new(
+            "k".to_string(),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
+            Some(2.0),
+            None,
+            None,
+            100,
+        );
         assert_eq!(too_fast.speed, Some(1.2));
     }
 
     #[test]
     fn test_unavailable_with_empty_or_placeholder_key() {
-        let empty = ElevenLabsProvider::new(String::new(), None, None, None, None, None, 100);
+        let empty = ElevenLabsProvider::new(
+            String::new(),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
+            None,
+            None,
+            None,
+            100,
+        );
         assert!(!empty.is_available());
 
         let placeholder = ElevenLabsProvider::new(
             "${ELEVENLABS_API_KEY}".to_string(),
-            None,
-            None,
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
             None,
             None,
             None,
@@ -282,8 +305,15 @@ mod tests {
 
     #[test]
     fn test_cost_estimation_flash() {
-        let provider =
-            ElevenLabsProvider::new("test-key".to_string(), None, None, None, None, None, 100);
+        let provider = ElevenLabsProvider::new(
+            "test-key".to_string(),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
+            None,
+            None,
+            None,
+            100,
+        );
         // 1M chars × $0.00006 = $60
         let cost = provider.estimate_cost(1_000_000);
         assert!((cost - 60.0).abs() < 0.001);
@@ -293,8 +323,8 @@ mod tests {
     fn test_cost_estimation_multilingual() {
         let provider = ElevenLabsProvider::new(
             "test-key".to_string(),
-            None,
-            Some("eleven_multilingual_v2".to_string()),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_multilingual_v2".to_string(),
             None,
             None,
             None,
@@ -307,8 +337,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_speak_empty_message() {
-        let provider =
-            ElevenLabsProvider::new("test-key".to_string(), None, None, None, None, None, 100);
+        let provider = ElevenLabsProvider::new(
+            "test-key".to_string(),
+            "21m00Tcm4TlvDq8ikWAM".to_string(),
+            "eleven_flash_v2_5".to_string(),
+            None,
+            None,
+            None,
+            100,
+        );
         let result = provider.speak("").await.unwrap();
         assert!(!result);
     }

--- a/src/tts/google.rs
+++ b/src/tts/google.rs
@@ -105,13 +105,11 @@ struct TtsErrorDetail {
 }
 
 impl GoogleTtsProvider {
-    pub fn new(api_key: String, model: String, voice_name: Option<String>, volume: u32) -> Self {
-        let voice = voice_name.unwrap_or_else(|| "Zephyr".to_string());
-
+    pub fn new(api_key: String, model: String, voice_name: String, volume: u32) -> Self {
         Self {
             api_key,
             model,
-            voice_name: voice,
+            voice_name,
             volume,
         }
     }
@@ -272,11 +270,11 @@ mod tests {
         let provider = GoogleTtsProvider::new(
             "test-api-key".to_string(),
             "gemini-2.5-flash-preview-tts".to_string(),
-            None,
+            "Aoede".to_string(),
             100,
         );
         assert_eq!(provider.name(), "google");
-        assert_eq!(provider.voice_name, "Zephyr");
+        assert_eq!(provider.voice_name, "Aoede");
         assert_eq!(provider.volume, 100);
         assert!(provider.is_available());
     }
@@ -286,7 +284,7 @@ mod tests {
         let provider = GoogleTtsProvider::new(
             "test-api-key".to_string(),
             "gemini-2.5-flash-preview-tts".to_string(),
-            Some("Charon".to_string()),
+            "Charon".to_string(),
             75,
         );
         assert_eq!(provider.voice_name, "Charon");
@@ -298,7 +296,7 @@ mod tests {
         let provider = GoogleTtsProvider::new(
             String::new(),
             "gemini-2.5-flash-preview-tts".to_string(),
-            None,
+            "Aoede".to_string(),
             100,
         );
         assert!(!provider.is_available());
@@ -309,7 +307,7 @@ mod tests {
         let provider = GoogleTtsProvider::new(
             "test-api-key".to_string(),
             "gemini-2.5-flash-preview-tts".to_string(),
-            None,
+            "Aoede".to_string(),
             100,
         );
 
@@ -327,7 +325,7 @@ mod tests {
         let provider = GoogleTtsProvider::new(
             "test-api-key".to_string(),
             "gemini-2.5-flash-preview-tts".to_string(),
-            None,
+            "Aoede".to_string(),
             100,
         );
         let result = provider.speak("").await.unwrap();

--- a/src/tts/mod.rs
+++ b/src/tts/mod.rs
@@ -141,7 +141,12 @@ pub fn create_single_tts(config: &TtsProviderConfig) -> Result<Box<dyn TtsProvid
                 )
             })?;
 
-            let voice = config.voice.clone();
+            // Voice is required for Google TTS — no hardcoded default.
+            let voice = config.voice.clone().ok_or_else(|| {
+                VoiceError::Config(
+                    "Google TTS voice is required. Specify in config, e.g., 'Aoede'".into(),
+                )
+            })?;
             Ok(Box::new(GoogleTtsProvider::new(
                 api_key, model, voice, volume,
             )))
@@ -151,7 +156,13 @@ pub fn create_single_tts(config: &TtsProviderConfig) -> Result<Box<dyn TtsProvid
                 VoiceError::Config("Cloud TTS requires service_account_key".into())
             })?;
 
-            let voice = config.voice.clone();
+            // Voice is required — no hardcoded default.
+            let voice = config.voice.clone().ok_or_else(|| {
+                VoiceError::Config(
+                    "Cloud TTS voice is required. Specify in config, e.g., 'en-US-Standard-A'"
+                        .into(),
+                )
+            })?;
             let language_code = config.language_code.clone();
             Ok(Box::new(CloudTtsProvider::new(
                 sa_json,
@@ -167,7 +178,12 @@ pub fn create_single_tts(config: &TtsProviderConfig) -> Result<Box<dyn TtsProvid
                 )
             })?;
 
-            let voice = config.voice.clone();
+            // Voice is required — no hardcoded default.
+            let voice = config.voice.clone().ok_or_else(|| {
+                VoiceError::Config(
+                    "xAI TTS voice is required. Specify in config, e.g., 'eve'".into(),
+                )
+            })?;
             let language = config.language_code.clone();
             Ok(Box::new(XaiTtsProvider::new(
                 api_key, voice, language, volume,
@@ -181,8 +197,18 @@ pub fn create_single_tts(config: &TtsProviderConfig) -> Result<Box<dyn TtsProvid
                 )
             })?;
 
-            let voice = config.voice.clone();
-            let model = config.model.clone();
+            // Voice and model are required — no hardcoded defaults.
+            let voice = config.voice.clone().ok_or_else(|| {
+                VoiceError::Config(
+                    "ElevenLabs voice is required. Specify a Voice ID in config.".into(),
+                )
+            })?;
+            let model = config.model.clone().ok_or_else(|| {
+                VoiceError::Config(
+                    "ElevenLabs model is required. Specify in config, e.g., 'eleven_flash_v2_5'"
+                        .into(),
+                )
+            })?;
             let speed = config.speed;
             let stability = config.stability;
             let style = config.style;
@@ -210,30 +236,34 @@ pub fn create_single_tts(config: &TtsProviderConfig) -> Result<Box<dyn TtsProvid
     }
 }
 
-/// Create TTS provider by name (for CLI override)
-pub fn create_tts_by_name(
-    name: &str,
-    model: Option<String>,
-    voice: Option<String>,
+/// Resolve a CLI/hook-selected TTS engine to a provider, sourcing all attributes
+/// from the matching config entry. Only the voice/volume the caller explicitly set
+/// override config; `rate` is taken from the caller (macOS-only). The engine must
+/// exist in config — config is the single source of truth, so an absent engine is
+/// an error and no provider/model/voice value is ever hardcoded here.
+pub fn resolve_tts_provider(
+    providers: &[TtsProviderConfig],
+    aliases: &[&str],
+    voice: Option<&str>,
     rate: u32,
-    volume: u32,
-    api_key: Option<String>,
+    volume: Option<u32>,
 ) -> Result<Box<dyn TtsProvider>> {
-    let config = TtsProviderConfig {
-        name: name.to_string(),
-        model,
-        voice,
-        api_key,
-        rate: Some(rate),
-        volume: Some(volume),
-        path: None,
-        service_account_key: None,
-        language_code: None,
-        speed: None,
-        stability: None,
-        style: None,
-    };
-    create_single_tts(&config)
+    let base = providers
+        .iter()
+        .find(|p| aliases.contains(&p.name.to_lowercase().as_str()))
+        .ok_or_else(|| {
+            VoiceError::Config(format!("{} provider not found in config", aliases[0]))
+        })?;
+
+    let mut resolved = base.clone();
+    if let Some(v) = voice {
+        resolved.voice = Some(v.to_string());
+    }
+    if let Some(vol) = volume {
+        resolved.volume = Some(vol);
+    }
+    resolved.rate = Some(rate);
+    create_single_tts(&resolved)
 }
 
 #[cfg(test)]
@@ -359,11 +389,48 @@ mod tests {
     }
 
     #[test]
-    fn test_create_tts_by_name_macos() {
-        let result =
-            create_tts_by_name("macos", None, Some("Tingting".to_string()), 200, 100, None);
+    fn test_resolve_tts_provider_uses_config_and_cli_override() {
+        let providers = vec![TtsProviderConfig {
+            name: "macos".to_string(),
+            model: None,
+            voice: Some("Meijia".to_string()),
+            api_key: None,
+            rate: Some(200),
+            volume: None,
+            path: None,
+            service_account_key: None,
+            language_code: None,
+            speed: None,
+            stability: None,
+            style: None,
+        }];
+
+        // CLI voice override wins over config voice; engine sourced from config.
+        let result = resolve_tts_provider(
+            &providers,
+            &["macos", "say"],
+            Some("Tingting"),
+            250,
+            Some(80),
+        );
         assert!(result.is_ok());
         assert_eq!(result.unwrap().name(), "macos");
+    }
+
+    #[test]
+    fn test_resolve_tts_provider_errors_when_engine_absent() {
+        let providers: Vec<TtsProviderConfig> = vec![];
+        let result = resolve_tts_provider(&providers, &["google", "gemini"], None, 200, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_tts_provider_macos_errors_when_absent() {
+        // config is the single source of truth: an unconfigured engine errors,
+        // even the credential-free macOS one.
+        let providers: Vec<TtsProviderConfig> = vec![];
+        let result = resolve_tts_provider(&providers, &["macos", "say"], None, 200, None);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/tts/xai.rs
+++ b/src/tts/xai.rs
@@ -41,15 +41,11 @@ struct XaiOutputFormat {
 }
 
 impl XaiTtsProvider {
-    pub fn new(
-        api_key: String,
-        voice_id: Option<String>,
-        language: Option<String>,
-        volume: u32,
-    ) -> Self {
+    pub fn new(api_key: String, voice_id: String, language: Option<String>, volume: u32) -> Self {
         Self {
             api_key,
-            voice_id: voice_id.unwrap_or_else(|| "eve".to_string()),
+            voice_id,
+            // language is a neutral tuning value: unset = auto-detect.
             language: language.unwrap_or_else(|| "auto".to_string()),
             volume,
         }
@@ -164,7 +160,8 @@ mod tests {
 
     #[test]
     fn test_xai_provider_creation() {
-        let provider = XaiTtsProvider::new("test-api-key".to_string(), None, None, 100);
+        let provider =
+            XaiTtsProvider::new("test-api-key".to_string(), "eve".to_string(), None, 100);
         assert_eq!(provider.name(), "xai");
         assert_eq!(provider.voice_id, "eve");
         assert_eq!(provider.language, "auto");
@@ -176,7 +173,7 @@ mod tests {
     fn test_custom_voice_and_language() {
         let provider = XaiTtsProvider::new(
             "test-api-key".to_string(),
-            Some("rex".to_string()),
+            "rex".to_string(),
             Some("zh".to_string()),
             75,
         );
@@ -187,13 +184,14 @@ mod tests {
 
     #[test]
     fn test_empty_api_key() {
-        let provider = XaiTtsProvider::new(String::new(), None, None, 100);
+        let provider = XaiTtsProvider::new(String::new(), "eve".to_string(), None, 100);
         assert!(!provider.is_available());
     }
 
     #[test]
     fn test_cost_estimation() {
-        let provider = XaiTtsProvider::new("test-api-key".to_string(), None, None, 100);
+        let provider =
+            XaiTtsProvider::new("test-api-key".to_string(), "eve".to_string(), None, 100);
 
         // 1M characters = $4.20
         let cost_1m = provider.estimate_cost(1_000_000);
@@ -206,7 +204,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_speak_empty_message() {
-        let provider = XaiTtsProvider::new("test-api-key".to_string(), None, None, 100);
+        let provider =
+            XaiTtsProvider::new("test-api-key".to_string(), "eve".to_string(), None, 100);
         let result = provider.speak("").await.unwrap();
         assert!(!result);
     }


### PR DESCRIPTION
在 PR 上自動觸發 Claude code review，貼 inline 評論。

- 觸發：`pull_request` 的 `opened` / `synchronize`
- 使用 `anthropics/claude-code-action@v1`（官方目前介面）
- 聚焦 Rust 正確性、慣用法、安全性、效能

## 啟用前置條件（需手動）

1. 安裝 **Claude GitHub App** 到 `musingfox/SumVox`
2. 在 repo Settings → Secrets 設定 `ANTHROPIC_API_KEY`

merge 後，之後開的 PR 會自動被 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)