### PR TITLE
refactor(audio): extract shared run_afplay helper

### DIFF
--- a/src/audio/afplay.rs
+++ b/src/audio/afplay.rs
@@ -3,6 +3,42 @@
 
 use crate::error::{Result, VoiceError};
 use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Run `afplay -v {volume/100.0:.2} {file_path}` to completion (blocking).
+///
+/// # Arguments
+/// * `file_path` - Path to the audio file to play
+/// * `volume` - Volume level 0-100 (values above 100 are clamped to avoid
+///   amplification past `-v 1.0`)
+///
+/// # Errors
+/// Returns VoiceError::Voice on:
+/// - Failed to spawn afplay process ("Failed to run afplay: {e}")
+/// - afplay exited with non-zero status ("afplay exited with error")
+///
+/// Note: this only runs the command; it does not write or clean up temp files.
+pub fn run_afplay(file_path: &Path, volume: u32) -> Result<()> {
+    // afplay -v takes a float: 0.0 = silent, 1.0 = full volume. Clamp to 100 so
+    // a mis-configured volume can't amplify past 1.0 and over-drive the output.
+    let afplay_volume = volume.min(100) as f32 / 100.0;
+    let status = Command::new("afplay")
+        .arg("-v")
+        .arg(format!("{:.2}", afplay_volume))
+        .arg(file_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|e| VoiceError::Voice(format!("Failed to run afplay: {}", e)))?;
+
+    if !status.success() {
+        return Err(VoiceError::Voice("afplay exited with error".to_string()));
+    }
+
+    Ok(())
+}
 
 /// Play audio data using macOS afplay command
 ///
@@ -38,26 +74,13 @@ pub fn play_with_afplay(audio_data: &[u8], volume: u32, temp_file_prefix: &str) 
         .and_then(|mut f| f.write_all(audio_data))
         .map_err(|e| VoiceError::Voice(format!("Failed to write temp WAV: {}", e)))?;
 
-    // afplay -v takes a float: 0.0 = silent, 1.0 = full volume
-    let afplay_volume = volume as f32 / 100.0;
-    let status = std::process::Command::new("afplay")
-        .arg("-v")
-        .arg(format!("{:.2}", afplay_volume))
-        .arg(&tmp_path)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|e| VoiceError::Voice(format!("Failed to run afplay: {}", e)))?;
-
+    // Capture the result before cleanup so the temp file is removed on every
+    // path — including a spawn failure, which the pre-refactor `?` would have
+    // skipped, leaking the file.
+    let result = run_afplay(&tmp_path, volume);
     // Clean up temp file (best effort)
     let _ = std::fs::remove_file(&tmp_path);
-
-    if !status.success() {
-        return Err(VoiceError::Voice("afplay exited with error".to_string()));
-    }
-
-    Ok(())
+    result
 }
 
 #[cfg(test)]
@@ -100,6 +123,18 @@ mod tests {
         let wav_data = create_test_wav();
         let result = play_with_afplay(&wav_data, 50, "sumvox_test");
         // On non-macOS, afplay won't exist, so this should error
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to run afplay"));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn test_run_afplay_not_available() {
+        // On non-macOS, afplay won't exist, so spawning it should fail.
+        let result = run_afplay(Path::new("/tmp/sumvox_nonexistent.wav"), 50);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/src/audio/file.rs
+++ b/src/audio/file.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use rand::seq::SliceRandom;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Result, VoiceError};
 use crate::tts::TtsProvider;
@@ -100,26 +100,10 @@ impl AudioFileProvider {
 }
 
 /// Play an audio file to completion (blocking) using afplay.
-fn play_audio_blocking(file_path: &PathBuf, volume: u32) -> Result<()> {
+fn play_audio_blocking(file_path: &Path, volume: u32) -> Result<()> {
     tracing::debug!("Playing audio file: {:?}, volume: {}", file_path, volume);
 
-    // afplay -v takes a float: 0.0 = silent, 1.0 = full volume
-    let afplay_volume = volume as f32 / 100.0;
-    let status = std::process::Command::new("afplay")
-        .arg("-v")
-        .arg(format!("{:.2}", afplay_volume))
-        .arg(file_path)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|e| VoiceError::Voice(format!("Failed to run afplay: {}", e)))?;
-
-    if !status.success() {
-        return Err(VoiceError::Voice("afplay exited with error".to_string()));
-    }
-
-    Ok(())
+    crate::audio::afplay::run_afplay(file_path, volume)
 }
 
 #[async_trait]

--- a/src/tts/elevenlabs.rs
+++ b/src/tts/elevenlabs.rs
@@ -112,24 +112,11 @@ impl ElevenLabsProvider {
             .and_then(|mut f| f.write_all(audio_data))
             .map_err(|e| VoiceError::Voice(format!("Failed to write temp MP3: {}", e)))?;
 
-        let afplay_volume = self.volume as f32 / 100.0;
-        let status = std::process::Command::new("afplay")
-            .arg("-v")
-            .arg(format!("{:.2}", afplay_volume))
-            .arg(&tmp_path)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map_err(|e| VoiceError::Voice(format!("Failed to run afplay: {}", e)))?;
-
+        // Capture the result before cleanup so the temp file is removed on
+        // every path, including a spawn failure (the pre-refactor `?` skipped it).
+        let result = crate::audio::afplay::run_afplay(&tmp_path, self.volume);
         let _ = std::fs::remove_file(&tmp_path);
-
-        if !status.success() {
-            return Err(VoiceError::Voice("afplay exited with error".to_string()));
-        }
-
-        Ok(())
+        result
     }
 }
 


### PR DESCRIPTION
## What

三處重複的 afplay Command 建構收斂為單一共用 helper `run_afplay(&Path, u32) -> Result<()>`(位於 `src/audio/afplay.rs`),三處呼叫點改為 delegate。

## Why

`src/audio/afplay.rs`、`src/audio/file.rs`、`src/tts/elevenlabs.rs` 各自重複建立 afplay Command(volume 轉換、`-v {:.2}`、null 三 stdio、`.status()`、status 成功檢查)。抽成單一 helper 後,樹中只剩一處 `Command::new("afplay")`。

## Bug fixed (incidental)

集中化順手修掉一個既有 bug:原 `play_with_afplay`(afplay.rs)與 `elevenlabs.rs` 在 **afplay spawn 失敗**時,`?` 會在 `remove_file` 之前提早 return,洩漏暫存檔。新寫法先 capture 結果、必清檔再傳播,spawn 失敗路徑也保證清理。

## Behavior

- 錯誤字串 `"Failed to run afplay: {e}"`、`"afplay exited with error"` 逐字保留(受既有測試斷言)。
- helper 只負責執行,temp file 寫/清留各呼叫點(三處本就相異:.wav / .mp3 / 不寫)。
- `run_afplay` 將 volume clamp 至 ≤100,避免誤設值放大超過 `-v 1.0` 破音(集中化後的合理防護)。

## Verification

- `cargo clippy --lib -- -D warnings` 乾淨
- `cargo test --lib` 218 passed / 0 failed
- 新增 non-macOS `test_run_afplay_not_available` 直接覆蓋 helper 錯誤路徑

🤖 Generated with [Claude Code](https://claude.com/claude-code)