### PR TITLE
fix(tts): strip audio tags before providers that can't interpret them

### DIFF
--- a/src/hooks/claude_code.rs
+++ b/src/hooks/claude_code.rs
@@ -569,6 +569,11 @@ async fn speak_text(config: &SumvoxConfig, tts_opts: &TtsOptions, text: &str) ->
         }
         _ => {
             // Single provider mode - just try once
+            let text = if provider.supports_audio_tags() {
+                text
+            } else {
+                crate::tts::strip_leading_audio_tag(text)
+            };
             match provider.speak(text).await {
                 Ok(_) => {
                     tracing::debug!("TTS playback completed");
@@ -650,8 +655,13 @@ async fn speak_with_provider_fallback(
             tracing::info!("TTS cost estimate: ${:.6} for {} chars", cost, text.len());
         }
 
-        // Try to speak
-        match provider.speak(text).await {
+        // Try to speak (strip audio tags for providers that would read them aloud)
+        let provider_text = if provider.supports_audio_tags() {
+            text
+        } else {
+            crate::tts::strip_leading_audio_tag(text)
+        };
+        match provider.speak(provider_text).await {
             Ok(_) => {
                 tracing::debug!("TTS playback completed with {}", provider.name());
                 return Ok(());

--- a/src/tts/elevenlabs.rs
+++ b/src/tts/elevenlabs.rs
@@ -130,6 +130,10 @@ impl TtsProvider for ElevenLabsProvider {
         !self.api_key.is_empty() && !self.api_key.starts_with("${")
     }
 
+    fn supports_audio_tags(&self) -> bool {
+        true
+    }
+
     async fn speak(&self, text: &str) -> Result<bool> {
         if text.trim().is_empty() {
             tracing::warn!("Empty message, skipping voice notification");

--- a/src/tts/mod.rs
+++ b/src/tts/mod.rs
@@ -30,6 +30,28 @@ pub trait TtsProvider: Send + Sync {
     /// Estimate cost per character (for cloud providers)
     /// Returns 0.0 for local engines
     fn estimate_cost(&self, char_count: usize) -> f64;
+
+    /// Whether this provider interprets `[tag]`-style audio/emotion tags
+    /// (e.g. ElevenLabs eleven_v3). Providers that don't must have such
+    /// tags stripped before speaking, or they get read aloud literally.
+    fn supports_audio_tags(&self) -> bool {
+        false
+    }
+}
+
+/// Strip a single leading `[tag]` (e.g. "[satisfied] ") from text meant for
+/// providers that don't interpret audio tags, so they don't read it aloud.
+pub fn strip_leading_audio_tag(text: &str) -> &str {
+    let trimmed = text.trim_start();
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            let tag = &rest[..end];
+            if !tag.is_empty() && tag.chars().all(|c| c.is_ascii_alphabetic()) {
+                return rest[end + 1..].trim_start();
+            }
+        }
+    }
+    text
 }
 
 /// TTS Engine type for CLI selection
@@ -269,6 +291,21 @@ pub fn resolve_tts_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_strip_leading_audio_tag() {
+        assert_eq!(
+            strip_leading_audio_tag("[satisfied] 已經完成任務了"),
+            "已經完成任務了"
+        );
+        assert_eq!(strip_leading_audio_tag("[excited] done"), "done");
+        assert_eq!(strip_leading_audio_tag("沒有標籤的句子"), "沒有標籤的句子");
+        assert_eq!(
+            strip_leading_audio_tag("[123] not a tag"),
+            "[123] not a tag"
+        );
+        assert_eq!(strip_leading_audio_tag("[unclosed tag"), "[unclosed tag");
+    }
 
     #[test]
     fn test_tts_engine_from_str() {


### PR DESCRIPTION
## Summary
- Stop hooks read "[satisfied]"/"[cheerful]"/"[concerned]"/"[excited]" literally when ElevenLabs quota runs out and the `auto` fallback drops to macOS/Google/xai — those engines don't understand ElevenLabs' `[tag]` audio-tag syntax.
- Adds `TtsProvider::supports_audio_tags()` (default `false`, `true` only for ElevenLabs) and strips a leading `[tag]` from the text before calling `speak()` on any provider that doesn't support it.

## Test plan
- [x] `cargo test --lib` (219 passed)
- [x] `cargo build --release`
- [x] Manual repro: `sumvox say --tts macos "[satisfied] 已經完成任務了"` now speaks only "已經完成任務了"
