### PR TITLE
fix(tts): honor volume for macOS say via afplay

### DIFF
--- a/src/tts/macos.rs
+++ b/src/tts/macos.rs
@@ -1,16 +1,25 @@
 // macOS say command TTS provider
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use async_trait::async_trait;
 use tokio::process::Command;
 
 use super::TtsProvider;
 use crate::error::{Result, VoiceError};
 
+// Per-call counter so the temp path is unique even for concurrent calls that
+// share a PID — same collision-safety scheme as audio/normalize.rs.
+static CALL_SEQ: AtomicU64 = AtomicU64::new(0);
+
 /// macOS TTS provider using the built-in `say` command
 pub struct MacOsTtsProvider {
     voice_name: Option<String>,
     rate: u32,
-    #[allow(dead_code)] // macOS say doesn't support volume control
+    // `say` itself has no volume flag, so we render to a file and let afplay
+    // apply `-v {volume/100}` on playback. This also routes macOS TTS through
+    // the same afplay choke point as every other provider (honors the volume
+    // knob on output devices with no software system volume, drives the avatar).
     volume: u32,
 }
 
@@ -42,12 +51,24 @@ impl TtsProvider for MacOsTtsProvider {
         }
 
         tracing::info!(
-            "Speaking with macOS say: voice={:?}, rate={}",
+            "Speaking with macOS say: voice={:?}, rate={}, volume={}",
             self.voice_name,
-            self.rate
+            self.rate,
+            self.volume
         );
 
+        // Render to a temp AIFF, then play via afplay so the volume knob applies.
+        // Qualify by PID + per-call counter so concurrent invocations (rapid
+        // `sumvox say` calls that don't hold the hook queue lock, or across
+        // processes) never clobber each other's file.
+        let aiff_path = std::env::temp_dir().join(format!(
+            "sumvox_macos_{}_{}.aiff",
+            std::process::id(),
+            CALL_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+
         let mut cmd = Command::new("say");
+        cmd.arg("-o").arg(&aiff_path);
 
         // Only add -v argument if voice is specified and not empty
         if let Some(ref voice) = self.voice_name {
@@ -58,16 +79,23 @@ impl TtsProvider for MacOsTtsProvider {
 
         cmd.arg("-r").arg(self.rate.to_string()).arg(text);
 
-        // Blocking: wait for completion
+        // Blocking: wait for synthesis to finish
         let output = cmd
             .output()
             .await
             .map_err(|e| VoiceError::Voice(format!("Say command failed: {}", e)))?;
 
         if !output.status.success() {
+            // `say` may have left a partial file behind before failing.
+            let _ = std::fs::remove_file(&aiff_path);
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(VoiceError::Voice(format!("Say command failed: {}", stderr)));
         }
+
+        // Play with afplay -v; clean up on every path (including playback error).
+        let result = crate::audio::afplay::run_afplay(&aiff_path, self.volume);
+        let _ = std::fs::remove_file(&aiff_path);
+        result?;
 
         tracing::debug!("Voice playback completed (blocking)");
 
@@ -119,5 +147,15 @@ mod tests {
         let provider = MacOsTtsProvider::new(Some("Tingting".to_string()), 200, 100);
         let result = provider.speak("   ").await.unwrap();
         assert!(!result);
+    }
+
+    // Exercises the full render-to-file + afplay path at a low volume; fails if
+    // `say -o` or the afplay handoff breaks. Uses volume 1 to stay near-silent.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_speak_renders_and_plays() {
+        let provider = MacOsTtsProvider::new(None, 300, 1);
+        let result = provider.speak("test").await.unwrap();
+        assert!(result);
     }
 }


### PR DESCRIPTION
## 問題

macOS \`say\` 沒有音量參數,原本 \`MacOsTtsProvider\` 的 \`volume\` 欄位標了 \`#[allow(dead_code)]\` 直接被忽略 —— 設定的音量(如 \`notification_volume\`)對通知**完全無效**,\`say\` 一律以系統音量播放。

在系統音量不可控的輸出裝置上(螢幕/DAC 回報 \`output volume: missing value\`),這代表通知永遠是硬體滿刻度、整段大聲,且 config 的 volume 旋鈕碰不到它。

## 修法

改用 \`say -o tmp.aiff\` 產檔,再走 \`afplay -v {volume/100}\` 播放:

- 音量終於生效(\`notification_volume = 40\` → \`-v 0.40\`)
- 與其他所有 provider 一樣經過 afplay 這個單一 choke point(順帶讓 menu bar avatar 嘴型對 macOS say 也會動)
- temp 檔在每條路徑(含播放錯誤)都清理

## 測試

- \`cargo build\` / \`cargo clippy\` clean
- 新增 macOS-gated 測試跑完整 render+afplay 路徑(volume=1 近乎靜音)
- 實跑 \`sumvox say "測試" --tts macos\` 確認 \`volume=40\` 正確帶入 afplay

## 備註

SoundSource 開頭漏音是其 ACE 攔截延遲的行為,程式端解不掉;搭配把 SoundSource 內 \`afplay\` 設回 100%、由 sumvox 的 \`-v\` 控音量即可根除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)